### PR TITLE
Update for Xcode 14.1+

### DIFF
--- a/DeliveryReceiptNotificationService/Info.plist
+++ b/DeliveryReceiptNotificationService/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>

--- a/Podfile
+++ b/Podfile
@@ -1,12 +1,12 @@
 # Uncomment the next line to define a global platform for your project
-platform :ios, '9.0'
+platform :ios, '12.0'
 
 target 'DeliveryReceiptNotificationService' do
   # Comment the next line if you don't want to use dynamic frameworks
   use_frameworks!
 
   # Pods for DeliveryReceiptNotificationService
-  pod 'SendBirdSDK', '~> 3.1.0'
+  pod 'SendBirdSDK', '~> 3.1.44'
 end
 
 target 'SendBird-iOS' do
@@ -14,7 +14,7 @@ target 'SendBird-iOS' do
   use_frameworks!
 
   # Pods for SendBird-iOS
-  pod 'SendBirdSDK', '~> 3.1.0'
+  pod 'SendBirdSDK', '~> 3.1.44'
   pod 'AlamofireImage', '~> 3.4'
   pod 'RSKImageCropper'
   pod 'NYTPhotoViewer', '~> 1.1.0'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -11,14 +11,14 @@ PODS:
     - NYTPhotoViewer/Core
   - NYTPhotoViewer/Core (1.1.0)
   - RSKImageCropper (3.0.2)
-  - SendBirdSDK (3.1.0)
+  - SendBirdSDK (3.1.44)
 
 DEPENDENCIES:
   - AlamofireImage (~> 3.4)
   - FLAnimatedImage (~> 1.0)
   - NYTPhotoViewer (~> 1.1.0)
   - RSKImageCropper
-  - SendBirdSDK (~> 3.1.0)
+  - SendBirdSDK (~> 3.1.44)
 
 SPEC REPOS:
   trunk:
@@ -35,8 +35,8 @@ SPEC CHECKSUMS:
   FLAnimatedImage: 8f3e854ebf9680b71f0b6e700939687fc4d82b4b
   NYTPhotoViewer: e80e8767f3780d2df37c6f72cbab15d6c7232911
   RSKImageCropper: 1ac71e9a82e3f41eea3eedfff8eacb0d3821c9ec
-  SendBirdSDK: ac0dbc957ec62845b12da4f0a90f4261724face8
+  SendBirdSDK: 5157bd3e70db9d0bb23e27a8f4744125dbf85536
 
-PODFILE CHECKSUM: a6b34eaf74dc37a238d058002e645b98f7e3e1d4
+PODFILE CHECKSUM: 1c9f1aa45643dca3a6aea4806f235a3b80300125
 
-COCOAPODS: 1.11.2
+COCOAPODS: 1.12.0

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -2,7 +2,7 @@ PODS:
   - Alamofire (4.9.1)
   - AlamofireImage (3.6.0):
     - Alamofire (~> 4.9)
-  - FLAnimatedImage (1.0.16)
+  - FLAnimatedImage (1.0.17)
   - NYTPhotoViewer (1.1.0):
     - NYTPhotoViewer/AnimatedGifSupport (= 1.1.0)
     - NYTPhotoViewer/Core (= 1.1.0)
@@ -10,8 +10,8 @@ PODS:
     - FLAnimatedImage (~> 1.0.8)
     - NYTPhotoViewer/Core
   - NYTPhotoViewer/Core (1.1.0)
-  - RSKImageCropper (3.0.2)
-  - SendBirdSDK (3.1.44)
+  - RSKImageCropper (4.0.0)
+  - SendBirdSDK (3.1.47)
 
 DEPENDENCIES:
   - AlamofireImage (~> 3.4)
@@ -32,10 +32,10 @@ SPEC REPOS:
 SPEC CHECKSUMS:
   Alamofire: 85e8a02c69d6020a0d734f6054870d7ecb75cf18
   AlamofireImage: be9963c6582d68b39e89191f64c82a7d7bf40fdd
-  FLAnimatedImage: 8f3e854ebf9680b71f0b6e700939687fc4d82b4b
+  FLAnimatedImage: bbf914596368867157cc71b38a8ec834b3eeb32b
   NYTPhotoViewer: e80e8767f3780d2df37c6f72cbab15d6c7232911
-  RSKImageCropper: 1ac71e9a82e3f41eea3eedfff8eacb0d3821c9ec
-  SendBirdSDK: 5157bd3e70db9d0bb23e27a8f4744125dbf85536
+  RSKImageCropper: 90dfe482402fb8a40cabd5fea65186d9102cc425
+  SendBirdSDK: 9f90bf0652b2b3ada11cda2e160c6eb511aea7f7
 
 PODFILE CHECKSUM: 1c9f1aa45643dca3a6aea4806f235a3b80300125
 

--- a/SendBird-iOS.xcodeproj/project.pbxproj
+++ b/SendBird-iOS.xcodeproj/project.pbxproj
@@ -131,7 +131,7 @@
 		E2D0C15121935A580080A5F3 /* GroupChannelIncomingAudioFileMessageTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2D0C14F21935A580080A5F3 /* GroupChannelIncomingAudioFileMessageTableViewCell.swift */; };
 		E2D0C15221935A580080A5F3 /* GroupChannelIncomingAudioFileMessageTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = E2D0C15021935A580080A5F3 /* GroupChannelIncomingAudioFileMessageTableViewCell.xib */; };
 		E2FE95112489362800169552 /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2FE95102489362800169552 /* NotificationService.swift */; };
-		E2FE95152489362800169552 /* DeliveryReceiptNotificationService.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = E2FE950E2489362800169552 /* DeliveryReceiptNotificationService.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		E2FE95152489362800169552 /* DeliveryReceiptNotificationService.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = E2FE950E2489362800169552 /* DeliveryReceiptNotificationService.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -145,15 +145,15 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
-		E2FE95192489362800169552 /* Embed App Extensions */ = {
+		E2FE95192489362800169552 /* Embed Foundation Extensions */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
 			dstPath = "";
 			dstSubfolderSpec = 13;
 			files = (
-				E2FE95152489362800169552 /* DeliveryReceiptNotificationService.appex in Embed App Extensions */,
+				E2FE95152489362800169552 /* DeliveryReceiptNotificationService.appex in Embed Foundation Extensions */,
 			);
-			name = "Embed App Extensions";
+			name = "Embed Foundation Extensions";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXCopyFilesBuildPhase section */
@@ -750,7 +750,7 @@
 				E21CDFBE2165619000839683 /* Frameworks */,
 				E21CDFBF2165619000839683 /* Resources */,
 				57774F9CC0D03BA2A16C5DCD /* [CP] Embed Pods Frameworks */,
-				E2FE95192489362800169552 /* Embed App Extensions */,
+				E2FE95192489362800169552 /* Embed Foundation Extensions */,
 			);
 			buildRules = (
 			);
@@ -787,11 +787,12 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 1150;
-				LastUpgradeCheck = 1000;
+				LastUpgradeCheck = 1420;
 				ORGANIZATIONNAME = SendBird;
 				TargetAttributes = {
 					E21CDFC02165619000839683 = {
 						CreatedOnToolsVersion = 10.0;
+						LastSwiftMigration = "";
 						SystemCapabilities = {
 							com.apple.BackgroundModes = {
 								enabled = 1;
@@ -1098,6 +1099,7 @@
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
@@ -1159,6 +1161,7 @@
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
@@ -1197,17 +1200,19 @@
 				CODE_SIGN_ENTITLEMENTS = "SendBird-iOS/SendBird-iOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 3.1.44;
 				DEVELOPMENT_TEAM = RM4A5PXTUX;
 				INFOPLIST_FILE = "SendBird-iOS/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
+				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.sendbird.sample4;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				"SWIFT_ACTIVE_COMPILATION_CONDITIONS[arch=*]" = SIMULATOR;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -1221,16 +1226,18 @@
 				CODE_SIGN_ENTITLEMENTS = "SendBird-iOS/SendBird-iOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 3.1.44;
 				DEVELOPMENT_TEAM = RM4A5PXTUX;
 				INFOPLIST_FILE = "SendBird-iOS/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
+				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.sendbird.sample4;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
@@ -1243,6 +1250,7 @@
 				CODE_SIGN_ENTITLEMENTS = DeliveryReceiptNotificationService/DeliveryReceiptNotificationService.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 3.1.44;
 				DEVELOPMENT_TEAM = RM4A5PXTUX;
 				INFOPLIST_FILE = DeliveryReceiptNotificationService/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.5;
@@ -1267,6 +1275,7 @@
 				CODE_SIGN_ENTITLEMENTS = DeliveryReceiptNotificationService/DeliveryReceiptNotificationService.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 3.1.44;
 				DEVELOPMENT_TEAM = RM4A5PXTUX;
 				INFOPLIST_FILE = DeliveryReceiptNotificationService/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.5;

--- a/SendBird-iOS.xcodeproj/xcshareddata/xcschemes/SendBird-iOS.xcscheme
+++ b/SendBird-iOS.xcodeproj/xcshareddata/xcschemes/SendBird-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1020"
+   LastUpgradeVersion = "1420"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/SendBird-iOS/AppDelegate.swift
+++ b/SendBird-iOS/AppDelegate.swift
@@ -24,7 +24,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // New init with option to use local caching or not.
         SBDMain.connect(withUserId: "", accessToken: "", apiHost: "", wsHost: "", completionHandler: nil)
-        SBDMain.initWithApplicationId("9880C4C1-E6C8-46E8-A8F1-D5890D598C08", useCaching: true, migrationStartHandler: {
+        SBDMain.initWithApplicationId("9DA1B1F4-0BE6-4DA8-82C5-2E81DAB56F23", useCaching: true, migrationStartHandler: {
             print( "Application: Called when there's an upgrade in db.")
         
         }, completionHandler: { error in
@@ -173,6 +173,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
             break
         case .off:
             return
+        @unknown default:
+            break
         }
         
         // Do Not Disturb - Need to implement as a function
@@ -349,10 +351,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     private func compareVersions(version1: String, version2: String) -> Int {
         var ret: Int = 0
         
-        var v1:[Int] = version1.split(separator: ".").map { (substring) -> Int in
+        let v1:[Int] = version1.split(separator: ".").map { (substring) -> Int in
             return Int(substring)!
         }
-        var v2 = version2.split(separator: ".").map { (substring) -> Int in
+        let v2 = version2.split(separator: ".").map { (substring) -> Int in
             return Int(substring)!
         }
         

--- a/SendBird-iOS/Assets.xcassets/btn_delete_user.imageset/Contents.json
+++ b/SendBird-iOS/Assets.xcassets/btn_delete_user.imageset/Contents.json
@@ -1,0 +1,23 @@
+{
+  "images" : [
+    {
+      "filename" : "btn_delete.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "filename" : "btn_delete-2.png",
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "filename" : "btn_delete-3.png",
+      "idiom" : "universal",
+      "scale" : "3x"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SendBird-iOS/GroupChannel/GroupChannelChat/GroupChannelChatViewController.swift
+++ b/SendBird-iOS/GroupChannel/GroupChannelChat/GroupChannelChatViewController.swift
@@ -279,7 +279,7 @@ class GroupChannelChatViewController: UIViewController, UITableViewDelegate, UIT
         
         var i = 0
         if initial {
-            channel.markAsRead(){ error in
+            channel.markAsRead { error in
                 guard error == nil else {
                     // Handle error.
                     return
@@ -1476,7 +1476,7 @@ class GroupChannelChatViewController: UIViewController, UITableViewDelegate, UIT
     func channel(_ sender: SBDBaseChannel, didReceive message: SBDBaseMessage) {
         if sender == self.channel {
             guard let channel = self.channel else { return }
-            channel.markAsRead(){ error in
+            channel.markAsRead { error in
                 guard error == nil else {
                     // Handle error.
                     return
@@ -2021,7 +2021,7 @@ class GroupChannelChatViewController: UIViewController, UITableViewDelegate, UIT
                     let baseMessage = self.messages[index]
                     if baseMessage is SBDFileMessage {
                         let fileMessage = baseMessage as! SBDFileMessage
-                        if fileMessage.requestId.isEmpty && fileMessage.requestId == preSendMessageRequest {
+                        if !fileMessage.requestId.isEmpty && fileMessage.requestId == preSendMessageRequest {
                             self.determineScrollLock()
                             let indexPath = IndexPath(row: index, section: 0)
                             self.messageTableView.reloadRows(at: [indexPath], with: .none)
@@ -2112,7 +2112,7 @@ class GroupChannelChatViewController: UIViewController, UITableViewDelegate, UIT
                     let baseMessage = self.messages[index]
                     if baseMessage is SBDFileMessage {
                         let fileMessage = baseMessage as! SBDFileMessage
-                        if fileMessage.requestId.isEmpty && fileMessage.requestId == preSendMessageRequest {
+                        if !fileMessage.requestId.isEmpty && fileMessage.requestId == preSendMessageRequest {
                             self.determineScrollLock()
                             let indexPath = IndexPath(row: index, section: 0)
                             self.messageTableView.reloadRows(at: [indexPath], with: .none)
@@ -2496,7 +2496,7 @@ class GroupChannelChatViewController: UIViewController, UITableViewDelegate, UIT
                         let baseMessage = self.messages[index]
                         if baseMessage is SBDFileMessage {
                             let fileMessage = baseMessage as! SBDFileMessage
-                            if fileMessage.requestId.isEmpty && fileMessage.requestId == preSendMessage!.requestId {
+                            if !fileMessage.requestId.isEmpty && fileMessage.requestId == preSendMessage!.requestId {
                                 self.determineScrollLock()
                                 let indexPath = IndexPath(row: index, section: 0)
                                 if self.sendingImageVideoMessage[preSendMessage!.requestId] == false {

--- a/SendBird-iOS/GroupChannel/GroupChannels/GroupChannelsViewController.swift
+++ b/SendBird-iOS/GroupChannel/GroupChannels/GroupChannelsViewController.swift
@@ -173,7 +173,7 @@ class GroupChannelsViewController: UIViewController, UITableViewDelegate, UITabl
     }
     
     func buildTypingIndicatorLabel(channel: SBDGroupChannel) -> String {
-        let typingMembers = channel.getTypingMembers()
+        let typingMembers = channel.getTypingUsers()
         if typingMembers == nil || typingMembers?.count == 0 {
             return ""
         }
@@ -318,6 +318,9 @@ class GroupChannelsViewController: UIViewController, UITableViewDelegate, UITabl
             break
         case .off:
             cell.notiOffIconImageView.isHidden = false
+            break
+        @unknown default:
+            cell.notiOffIconImageView.isHidden = true
             break
         }
 

--- a/SendBird-iOS/Info.plist
+++ b/SendBird-iOS/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
 	<key>CFBundleVersion</key>
-	<string>3.0.90</string>
+	<string>3.1.44</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>LSSupportsOpeningDocumentsInPlace</key>

--- a/SendBird-iOS/Login/ConnectionManager.swift
+++ b/SendBird-iOS/Login/ConnectionManager.swift
@@ -127,7 +127,7 @@ class ConnectionManager: NSObject, SBDConnectionDelegate {
                     }
                     userInfo[NSLocalizedDescriptionKey] = theError.localizedDescription
                     userInfo[NSUnderlyingErrorKey] = theError
-                    let connectionError: NSError = NSError.init(domain: ErrorDomainConnection, code: theError.code, userInfo: userInfo)
+                    let _: NSError = NSError.init(domain: ErrorDomainConnection, code: theError.code, userInfo: userInfo)
                     handler(user, nil)
                 }
                 return

--- a/SendBird-iOS/Misc/Utils/Utils.swift
+++ b/SendBird-iOS/Misc/Utils/Utils.swift
@@ -168,7 +168,7 @@ class Utils: NSObject {
     }
     
     static func buildTypingIndicatorLabel(channel: SBDGroupChannel) -> String {
-        if let typingMembers = channel.getTypingMembers() {
+        if let typingMembers = channel.getTypingUsers() {
             if typingMembers.count == 0 {
                 return ""
             }

--- a/SendBird-iOS/OpenChannel/OpenChannelChat/OpenChannelChatViewController.swift
+++ b/SendBird-iOS/OpenChannel/OpenChannelChat/OpenChannelChatViewController.swift
@@ -1776,7 +1776,7 @@ class OpenChannelChatViewController: UIViewController, UITableViewDelegate, UITa
                         let baseMessage = self.messages[index]
                         if baseMessage is SBDFileMessage {
                             let fileMessage = baseMessage as! SBDFileMessage
-                            if fileMessage.requestId.isEmpty && fileMessage.requestId == preSendMessage!.requestId {
+                            if !fileMessage.requestId.isEmpty && fileMessage.requestId == preSendMessage!.requestId {
                                 self.determineScrollLock()
                                 let indexPath = IndexPath(row: index, section: 0)
                                 if self.sendingImageVideoMessage[preSendMessage!.requestId] == false {

--- a/SendBird-iOS/OpenChannel/OpenChannelChat/OpenChannelChatViewController.swift
+++ b/SendBird-iOS/OpenChannel/OpenChannelChat/OpenChannelChatViewController.swift
@@ -204,8 +204,14 @@ class OpenChannelChatViewController: UIViewController, UITableViewDelegate, UITa
         if self.hasPrevious == false {
             return
         }
+        let params = SBDMessageListParams()
+
+        params.previousResultSize = 30
+        params.reverse = !initial
+        params.customType = nil
+        params.messageType = .all
         
-        channel.getPreviousMessages(byTimestamp: timestamp, limit: 30, reverse: !initial, messageType: .all, customType: nil, completionHandler: { (msgs, error) in
+        channel.getMessagesByTimestamp(timestamp, params: params) { (msgs, error) in
             if error != nil {
                 self.isLoading = false
                 
@@ -266,7 +272,7 @@ class OpenChannelChatViewController: UIViewController, UITableViewDelegate, UITa
                     }
                 }
             }
-        })
+        }
     }
     
     // MARK: - NotificationDelegate
@@ -1543,7 +1549,7 @@ class OpenChannelChatViewController: UIViewController, UITableViewDelegate, UITa
                         }
                     }
                 }, completionHandler: { (fileMessage, error) in
-                    guard let message = fileMessage else { return }
+                    guard fileMessage != nil else { return }
                     guard let fileMessageRequestId = fileMessage?.requestId else { return }
                     let preSendMessage = self.preSendMessages[fileMessageRequestId] as? SBDFileMessage
                     self.preSendMessages.removeValue(forKey: fileMessageRequestId)
@@ -1770,7 +1776,7 @@ class OpenChannelChatViewController: UIViewController, UITableViewDelegate, UITa
                         let baseMessage = self.messages[index]
                         if baseMessage is SBDFileMessage {
                             let fileMessage = baseMessage as! SBDFileMessage
-                            if fileMessage.requestId != nil && fileMessage.requestId == preSendMessage!.requestId {
+                            if fileMessage.requestId.isEmpty && fileMessage.requestId == preSendMessage!.requestId {
                                 self.determineScrollLock()
                                 let indexPath = IndexPath(row: index, section: 0)
                                 if self.sendingImageVideoMessage[preSendMessage!.requestId] == false {


### PR DESCRIPTION
### Background
Apple announced that starting April 25, 2023, iOS, iPadOS, and watchOS apps submitted to the App Store must be built with Xcode 14.1 or later(https://developer.apple.com/news/?id=jd9wcyov ).
It should be verified that all iOS SampleApps in Sendbird run on Xcode14.1+.

### Summary
- [change ApplicationId](https://github.com/sendbird/LocalCaching-iOS-Swift/commit/c6b6ae8316320a1f6b1354ab4c261f607c277e95)
- [Fix the use of deprecated methods](https://github.com/sendbird/LocalCaching-iOS-Swift/commit/763a7d2a1f93f1928974a69632e87c9f006c3f43)
- [Fix Lint errors](https://github.com/sendbird/LocalCaching-iOS-Swift/commit/2273f32cbd13f0640a98a0e500972e5861daea31)
- [Change the ios version(9.0 -> 12.0) of Podfile and update dependencies](https://github.com/sendbird/LocalCaching-iOS-Swift/commit/20e3ede821b3f327c7be1cc375a0367fa48081cb)


### Further Comments
